### PR TITLE
Email address not found bugfix

### DIFF
--- a/cork/cork.py
+++ b/cork/cork.py
@@ -464,6 +464,7 @@ class Cork(object):
                 if v['email_addr'] == email_addr:
                     username = k
                     break
+            else:    
                 raise AAAException("Email address not found.")
 
         else:  # username is provided


### PR DESCRIPTION
BUGFIX: exception "Email address not found." occurs every time when a fetched username is not a first item in collection.
