### PR TITLE
MongoDBBackend - Addition of username/password auth

### DIFF
--- a/cork/mongodb_backend.py
+++ b/cork/mongodb_backend.py
@@ -136,10 +136,12 @@ class MongoMultiValueTable(MongoTable):
 
 
 class MongoDBBackend(Backend):
-    def __init__(self, db_name='cork', hostname='localhost', port=27017, initialize=False):
+    def __init__(self, db_name='cork', hostname='localhost', port=27017, initialize=False, username=None, password=None):
         """Initialize MongoDB Backend"""
         connection = MongoClient(host=hostname, port=port)
         db = connection[db_name]
+        if username and password:
+            db.authenticate(username, password)
         self.users = MongoMultiValueTable('users', 'login', db.users)
         self.pending_registrations = MongoMultiValueTable(
             'pending_registrations',


### PR DESCRIPTION
Enables optional use of username and password for login to mongodb servers that require it (such as mongolabs).
