### PR TITLE
Support for optional memcached caching in mongodb_backend.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - pip install pymongo --use-mirrors
   - pip install scrypt --use-mirrors
   - pip install webtest --use-mirrors
+  - pip install python-memcached --use-mirrors
 
 before_script:
   - mysql -e 'create database myapp_test;' # username: "root", password: ""


### PR DESCRIPTION
Support for optional memcached caching is implemented, providing for a substantial improvement when remote mongodb servers are used. Support degrades gracefully for both missing the python-memcache module or not
having an active memcache server. There is a default memcache item decay time of 5 minutes, but that can be set separately. Use of memcached requires defining the host and port, default behaviour is the current non-cached behaviour.

Travis CI configuration updated to include requirement for memcache module.
