### PR TITLE
Tell sqlite to immediately commit all changes to avoid deadlocks

### DIFF
--- a/cork/sqlite_backend.py
+++ b/cork/sqlite_backend.py
@@ -219,7 +219,7 @@ class SQLiteBackend(base_backend.Backend):
             return self._connection
         except AttributeError:
             import sqlite3
-            self._connection = sqlite3.connect(self._filename)
+            self._connection = sqlite3.connect(self._filename, isolation_level=None)
             return self._connection
 
     def run_query(self, query):


### PR DESCRIPTION
Currently cork leaves sqlite transactions open, which means if you access the same database from different threads or processes, it is locked. This changes the isolation level so that changes are immediately committed, avoiding the problem.