### PR TITLE
Added kwargs to SqlAlchemyBackend init

### DIFF
--- a/cork/sqlalchemy_backend.py
+++ b/cork/sqlalchemy_backend.py
@@ -132,7 +132,7 @@ class SqlSingleValueTable(SqlTable):
 class SqlAlchemyBackend(base_backend.Backend):
 
     def __init__(self, db_full_url, users_tname='users', roles_tname='roles',
-            pending_reg_tname='register', initialize=False):
+            pending_reg_tname='register', initialize=False, **kwargs):
 
         if not sqlalchemy_available:
             raise RuntimeError("The SQLAlchemy library is not available.")
@@ -144,7 +144,7 @@ class SqlAlchemyBackend(base_backend.Backend):
             if is_py3 and db_url.startswith('mysql'):
                 print("WARNING: MySQL is not supported under Python3")
 
-            self._engine = create_engine(db_url, encoding='utf-8')
+            self._engine = create_engine(db_url, encoding='utf-8', **kwargs)
             try:
                 self._engine.execute("CREATE DATABASE %s" % db_name)
             except Exception as e:
@@ -155,7 +155,7 @@ class SqlAlchemyBackend(base_backend.Backend):
                 self._engine.execute("USE %s" % db_name)
 
         else:
-            self._engine = create_engine(db_full_url, encoding='utf-8')
+            self._engine = create_engine(db_full_url, encoding='utf-8', **kwargs)
 
 
         self._users = Table(users_tname, self._metadata,


### PR DESCRIPTION
In order to properly use MySQL you need to set SqlAlchemy options when calling create_engine.

The specific issue is that after some period of inactivity when bottle-cork tries to connect to MySQL again it fails with a "MySQL has gone" away error. 

http://docs.sqlalchemy.org/en/rel_0_8/faq.html#mysql-server-has-gone-away

This pull request adds the option to set arbitrary SQLAlchemy create_engine options.