### PR TITLE
Drop pycrypto dependency as it's not used anywhere

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     classifiers=CLASSIFIERS,
     install_requires=[
         'Bottle',
-        'pycrypto',
     ],
     extras_require={
         'scrypt': ["scrypt>=0.6.1"],


### PR DESCRIPTION
As far as I can tell the `Crypto` module is not used anywhere so the `pycrypto` dependency should be dropped.