### PR TITLE
Store role level as int

### DIFF
--- a/examples/simple_webapp.py
+++ b/examples/simple_webapp.py
@@ -158,7 +158,7 @@ def delete_user():
 @bottle.post('/create_role')
 def create_role():
     try:
-        aaa.create_role(post_get('role'), post_get('level'))
+        aaa.create_role(post_get('role'), int(post_get('level')))
         return dict(ok=True, msg='')
     except Exception, e:
         return dict(ok=False, msg=e.message)

--- a/examples/simple_webapp_decorated.py
+++ b/examples/simple_webapp_decorated.py
@@ -197,7 +197,7 @@ def delete_user():
 @bottle.post('/create_role')
 def create_role():
     try:
-        aaa.create_role(post_get('role'), post_get('level'))
+        aaa.create_role(post_get('role'), int(post_get('level')))
         return dict(ok=True, msg='')
     except Exception, e:
         return dict(ok=False, msg=e.message)


### PR DESCRIPTION
Previously, creating a role using the example admin page would store it as a string and break require() when comparing user level to required user level. Now it will convert to int before storing in json.